### PR TITLE
add support for layerdatatuples

### DIFF
--- a/src/napari_timelapse_processor/_tests/conftest.py
+++ b/src/napari_timelapse_processor/_tests/conftest.py
@@ -187,3 +187,25 @@ def create_4dmesh_layer_with_features():
     layer = Surface((vertices, faces))
     layer.features = features
     return layer
+
+
+@pytest.fixture
+def create_3d_layerdatatuple_with_features():
+    import pandas as pd
+
+    points = np.random.random((10, 3))
+    features = pd.DataFrame(
+        {
+            "feature1": np.random.random(len(points)),
+            "feature2": np.random.random(len(points)),
+        }
+    )
+
+    layerdatatuple = (
+        points,
+        {'features': features,
+         'name': 'pointcloud',
+        },
+        'points')
+             
+    return layerdatatuple

--- a/src/napari_timelapse_processor/_tests/test_timelapse_converter.py
+++ b/src/napari_timelapse_processor/_tests/test_timelapse_converter.py
@@ -218,3 +218,50 @@ def test_faces_index_after_stacking():
     assert result[1][0].max() == 2
     assert result[1][1].min() == 3
     assert result[1][1].max() == 5
+
+# def create_3d_layerdatatuple_with_features():
+#     import pandas as pd
+
+#     points = np.random.random((10, 3))
+#     features = pd.DataFrame(
+#         {
+#             "feature1": np.random.random(len(points)),
+#             "feature2": np.random.random(len(points)),
+#         }
+#     )
+
+#     layerdatatuple = (
+#         points,
+#         {'features': features,
+#          'name': 'pointcloud',
+#         },
+#         'points')
+             
+#     return layerdatatuple
+
+def test_convert_layerdatatuple(create_3d_layerdatatuple_with_features):
+    from napari_timelapse_processor import TimelapseConverter
+    import pandas as pd
+
+    Converter = TimelapseConverter()
+
+    # First we check conversion from list of 3D layerdatatuple to 4d layerdatatuple and back
+    list_of_3d_layerdatatuple = [create_3d_layerdatatuple_with_features for _ in range(5)]
+    converted_layerdatatuple = Converter.stack_data(
+        list_of_3d_layerdatatuple, layertype="napari.types.LayerDataTuple"
+    )
+
+    back_converted = Converter.unstack_data(
+        converted_layerdatatuple, layertype="napari.types.LayerDataTuple"
+    )
+
+    for i in range(5):
+        assert np.array_equal(
+            list_of_3d_layerdatatuple[i][0], back_converted[i][0]
+        )
+        features1 = list_of_3d_layerdatatuple[i][1]['features']
+        features2 = back_converted[i][1]['features'].drop('frame', axis=1)
+        assert features1.equals(features2)
+
+if __name__ == "__main__":
+    test_convert_layerdatatuple(create_3d_layerdatatuple_with_features)

--- a/src/napari_timelapse_processor/timelapse_converter.py
+++ b/src/napari_timelapse_processor/timelapse_converter.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from napari.layers import Image, Labels, Layer, Points, Surface, Vectors
+from napari.types import LayerDataTuple
 
 
 class TimelapseConverter:
@@ -49,11 +50,13 @@ class TimelapseConverter:
             Image: self._stack_layer,
             Labels: self._stack_layer,
             Layer: self._stack_layer,
+            LayerDataTuple: self._stack_layerdatatuple,
             "napari.types.PointsData": self._stack_points,
             "napari.types.VectorsData": self._stack_vectors,
             "napari.types.SurfaceData": self._stack_surfaces,
             "napari.types.ImageData": self._stack_image,
             "napari.types.LabelsData": self._stack_image,
+            "napari.types.LayerDataTuple": self._stack_layerdatatuple,
         }
 
         self.unstack_data_functions = {
@@ -63,11 +66,13 @@ class TimelapseConverter:
             Image: self._unstack_layer,
             Labels: self._unstack_layer,
             Layer: self._unstack_layer,
+            LayerDataTuple: self._unstack_layerdatatuple,
             "napari.types.PointsData": self._unstack_points,
             "napari.types.VectorsData": self._unstack_vectors,
             "napari.types.SurfaceData": self._unstack_surface,
             "napari.types.ImageData": self._unstack_image,
             "napari.types.LabelsData": self._unstack_image,
+            "napari.types.LayerDataTuple": self._unstack_layerdatatuple,
         }
 
         self.supported_data = list(self.stack_data_functions.keys())
@@ -304,6 +309,26 @@ class TimelapseConverter:
             surfaces[t] = (frame_points, frame_faces, frame_values)
 
         return surfaces
+    
+    def _stack_layerdatatuple(self, layers: list) -> LayerDataTuple:
+        """
+        Convert list of 3D layerdatatuples to single 4D layerdatatuple.
+        """
+
+        layers = [Layer.create(*ldt) for ldt in layers]
+        result = self._stack_layer(layers)
+        
+        return result.as_layer_data_tuple()
+    
+    def _unstack_layerdatatuple(self, layer: LayerDataTuple) -> list:
+        """
+        Convert a 4D layerdatatuple to list of 3D layerdatatuples
+        """
+        layer = Layer.create(*layer)
+        result = self._unstack_layer(layer)
+        
+        return [layer.as_layer_data_tuple() for layer in result]
+
 
     def _stack_layer(self, layers: list) -> Layer:
         """


### PR DESCRIPTION
This pull request introduces support for handling `LayerDataTuple` objects in the `TimelapseConverter` class, along with corresponding tests and fixtures. The changes enhance functionality by enabling stacking and unstacking of `LayerDataTuple` objects, which are now treated as a supported data type.

### Enhancements to `TimelapseConverter`:

* Added support for `LayerDataTuple` in the `stack_data_functions` and `unstack_data_functions` dictionaries, associating it with new methods `_stack_layerdatatuple` and `_unstack_layerdatatuple`. (`src/napari_timelapse_processor/timelapse_converter.py`, [[1]](diffhunk://#diff-a55a363d03807ad42cd9e409fd9448a9691eec25f224b1c9e1e645fd5b906111R53-R59) [[2]](diffhunk://#diff-a55a363d03807ad42cd9e409fd9448a9691eec25f224b1c9e1e645fd5b906111R69-R75)
* Implemented `_stack_layerdatatuple` to convert a list of 3D `LayerDataTuple` objects into a single 4D `LayerDataTuple`, and `_unstack_layerdatatuple` to perform the reverse operation. (`src/napari_timelapse_processor/timelapse_converter.py`, [src/napari_timelapse_processor/timelapse_converter.pyR313-R332](diffhunk://#diff-a55a363d03807ad42cd9e409fd9448a9691eec25f224b1c9e1e645fd5b906111R313-R332))
* Imported `LayerDataTuple` from `napari.types` to support the new functionality. (`src/napari_timelapse_processor/timelapse_converter.py`, [src/napari_timelapse_processor/timelapse_converter.pyR4](diffhunk://#diff-a55a363d03807ad42cd9e409fd9448a9691eec25f224b1c9e1e645fd5b906111R4))

### Testing and fixtures:

* Added a new pytest fixture, `create_3d_layerdatatuple_with_features`, to generate sample 3D `LayerDataTuple` objects with random features for testing. (`src/napari_timelapse_processor/_tests/conftest.py`, [src/napari_timelapse_processor/_tests/conftest.pyR190-R211](diffhunk://#diff-187ae8c6ae4b1b16fc4c4b9342993351e0cd2cb90adba86f84ce21afadb654cfR190-R211))
* Introduced the `test_convert_layerdatatuple` test to verify the correctness of stacking and unstacking operations for `LayerDataTuple` objects. (`src/napari_timelapse_processor/_tests/test_timelapse_converter.py`, [src/napari_timelapse_processor/_tests/test_timelapse_converter.pyR221-R267](diffhunk://#diff-8c627997ac719a5d3b83f30c4d619119b57482e23bf511c27c3999cddf254e70R221-R267))