### PR TITLE
catch zero-dimed metadata values

### DIFF
--- a/src/napari_timelapse_processor/timelapse_converter.py
+++ b/src/napari_timelapse_processor/timelapse_converter.py
@@ -364,10 +364,13 @@ class TimelapseConverter:
             for key in list(metadata_list[0].keys())
         }
         output_metadata = {
-            key: np.concatenate(metadata_values[key])
+            key: (
+                np.concatenate(metadata_values[key])
+                if all(np.ndim(v) > 0 for v in metadata_values[key])
+                else np.array(metadata_values[key])
+            )
             for key in metadata_values
         }
-
         # create a new layer with the stacked data
         output_layer = type(layers[0])(output_data)
         output_layer.features = output_features


### PR DESCRIPTION
This pull request refines the `_stack_layer` method in `timelapse_converter.py` to handle edge cases in metadata stacking. The change ensures that metadata values are concatenated only when all elements have dimensions greater than zero; otherwise, they are converted to a NumPy array.

Metadata handling improvements:

* [`src/napari_timelapse_processor/timelapse_converter.py`](diffhunk://#diff-a55a363d03807ad42cd9e409fd9448a9691eec25f224b1c9e1e645fd5b906111L367-L370): Updated the logic for stacking metadata in the `output_metadata` dictionary to handle cases where metadata values may include scalars or zero-dimensional arrays. This prevents errors during concatenation by using `np.array` as a fallback.