### PR TITLE
use git tags for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+#_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ Repository = "https://github.com/jo-mueller/napari-timelapse-processor.git"
 
 
 [build-system]
-requires = ["setuptools>=42.0.0", "wheel"]
+requires = ["setuptools>=42.0.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -60,9 +60,9 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
 
-
-[tool.setuptools.dynamic]
-version = {attr = "napari_timelapse_processor.__init__.__version__"}
+[tool.setuptools_scm]
+write_to = "src/napari_timelapse_processor/_version.py"
+fallback_version = "0.0.1+nogit"
 
 [tool.black]
 line-length = 79

--- a/src/napari_timelapse_processor/__init__.py
+++ b/src/napari_timelapse_processor/__init__.py
@@ -1,5 +1,3 @@
-__version__ = "0.1.0"
-
 from .frame_by_frame import frame_by_frame
 from .timelapse_converter import TimelapseConverter
 


### PR DESCRIPTION
This pull request updates the project configuration to use `setuptools_scm` for version management and removes the hardcoded version from the codebase. The changes ensure that versioning is more dynamic and aligned with the state of the repository.

### Project configuration updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L51-R51): Added `setuptools_scm` to the `requires` list under `[build-system]` to enable dynamic versioning.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L63-R65): Configured `setuptools_scm` to write the version to `src/napari_timelapse_processor/_version.py` and set a fallback version of `0.0.1+nogit`. Removed the `[tool.setuptools.dynamic]` section that previously defined the version attribute.

### Codebase updates:
* [`src/napari_timelapse_processor/__init__.py`](diffhunk://#diff-550b5f2a6d5133e6a6e1db5ca98ea958cc6cad6b5177516bcdd6c70f01454db2L1-L2): Removed the hardcoded `__version__` variable to rely on dynamic versioning provided by `setuptools_scm`.